### PR TITLE
Pull request - Add support for custom column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,7 @@
-# Wildside/Userstamps
+Fork of wildside/userstamps that allows custom `created/updated/deleted_by` column names similer to Laravel's `created/updated/deleted_at` constants.
 
-Provides an Eloquent trait to automatically maintain created_by and updated_by (and deleted_by when using SoftDeletes) on your models.
+To change the name, simply add the following to whichever class you are using userstamps in.
 
-## Requirements
-
-* This package requires PHP 5.6+
-* It works with Laravel 5.x (and may work with earlier versions too).
-
-## Installation
-
-Require this package with composer
-
-````
-composer require wildside/userstamps
-````
-
-Migrate your Model's table to include a `created_by` and `updated_by` (and `deleted_by` if using `SoftDeletes`).
-
-```php
-$table -> unsignedInteger('created_by') -> nullable() -> default(null) -> after('created_at');
-$table -> unsignedInteger('updated_by') -> nullable() -> default(null) -> after('updated_at');
-```
-
-Load the trait in your Model.
-
-```php
-use Wildside\Userstamps\Userstamps;
-
-class Example extends Model {
-
-    use Userstamps;
-}
-```
-
-The following methods become available on your models to help retrieve the users creating, updating and deleting (if using SoftDeletes).
-
-```php
-$model -> creator; // the user who created the model
-$model -> editor; // the user who last updated the model
-$model -> destroyer; // the user who deleted the model
-```
-
-If you want to manually set the `created_by` or `updated_by` properties on your model you can stop Userstamps being automatically maintained using the `stopUserstamping` method.
+    const CREATED_BY = 'new_created_by_col_name';
+    const UPDATED_BY = 'new_updated_by_col_name';
+    const DELETED_BY = 'new_deleted_by_col_name';

--- a/README.md
+++ b/README.md
@@ -1,7 +1,52 @@
-Fork of wildside/userstamps that allows custom `created/updated/deleted_by` column names similer to Laravel's `created/updated/deleted_at` constants.
+# Wildside/Userstamps
 
-To change the name, simply add the following to whichever class you are using userstamps in.
+Provides an Eloquent trait to automatically maintain created_by and updated_by (and deleted_by when using SoftDeletes) on your models.
 
-    const CREATED_BY = 'new_created_by_col_name';
-    const UPDATED_BY = 'new_updated_by_col_name';
-    const DELETED_BY = 'new_deleted_by_col_name';
+## Requirements
+
+* This package requires PHP 5.6+
+* It works with Laravel 5.x (and may work with earlier versions too).
+
+## Installation
+
+Require this package with composer
+
+````
+composer require wildside/userstamps
+````
+
+Migrate your Model's table to include a `created_by` and `updated_by` (and `deleted_by` if using `SoftDeletes`).
+
+```php
+$table -> unsignedInteger('created_by') -> nullable() -> default(null) -> after('created_at');
+$table -> unsignedInteger('updated_by') -> nullable() -> default(null) -> after('updated_at');
+```
+
+Load the trait in your Model.
+
+```php
+use Wildside\Userstamps\Userstamps;
+
+class Example extends Model {
+
+    use Userstamps;
+}
+```
+
+The following methods become available on your models to help retrieve the users creating, updating and deleting (if using SoftDeletes).
+
+```php
+$model -> creator; // the user who created the model
+$model -> editor; // the user who last updated the model
+$model -> destroyer; // the user who deleted the model
+```
+
+If you want to manually set the `created_by` or `updated_by` properties on your model you can stop Userstamps being automatically maintained using the `stopUserstamping` method.
+
+If you want to use custom `created_by`, `updated_by`, or `deleted_by` column names similer to Laravel's timestamp `created_at`, `updated_at`, and `deleted_at` constants, simply add the following to whichever class you are using userstamps in.
+
+```php
+const CREATED_BY = ''; // your custom created_by column name
+const UPDATED_BY = ''; // your custom updated_by column name
+const DELETED_BY = ''; // your custom deleted_by column name
+```

--- a/src/Listeners/Controller.php
+++ b/src/Listeners/Controller.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Wildside\Userstamps\Listeners;
+
+class Controller {
+    
+    public $created_by = 'created_by';
+    public $updated_by = 'updated_by';
+    public $deleted_by = 'deleted_by';
+    /**
+     * When the model is being created.
+     *
+     * @param Illuminate\Database\Eloquent\Model|static
+     * @return bool
+     */
+    public function prep($model)
+    {
+        if (! $model -> isUserstamping()) {
+            return false;
+        }
+    
+        if (defined(get_class($model).'::CREATED_BY')) $this->created_by = $model::CREATED_BY;
+        if (defined(get_class($model).'::UPDATED_BY')) $this->updated_by = $model::UPDATED_BY;
+        if (defined(get_class($model).'::DELETED_BY')) $this->deleted_by = $model::DELETED_BY;
+        
+        return true;
+    }
+}

--- a/src/Listeners/Creating.php
+++ b/src/Listeners/Creating.php
@@ -2,21 +2,21 @@
 
 namespace Wildside\Userstamps\Listeners;
 
-class Creating {
+class Creating extends Controller {
 
     /**
      * When the model is being created.
      *
-     * @param Illuminate\Database\Eloquent $model
+     * @param Illuminate\Database\Eloquent\Model|static
      * @return void
      */
     public function handle($model)
     {
-        if (! $model -> isUserstamping()) {
+        if (! $this->prep($model)) {
             return;
         }
 
-        $model -> created_by = auth() -> id();
-        $model -> updated_by = auth() -> id();
+        $model -> {$this->created_by} = auth() -> id();
+        $model -> {$this->updated_by} = auth() -> id();
     }
 }

--- a/src/Listeners/Deleting.php
+++ b/src/Listeners/Deleting.php
@@ -2,21 +2,21 @@
 
 namespace Wildside\Userstamps\Listeners;
 
-class Deleting {
+class Deleting extends Controller {
 
     /**
      * When the model is being deleted.
      *
-     * @param Illuminate\Database\Eloquent $model
+     * @param Illuminate\Database\Eloquent\Model|static
      * @return void
      */
     public function handle($model)
     {
-        if (! $model -> isUserstamping()) {
+        if (! $this->prep($model)) {
             return;
         }
 
-        $model -> deleted_by = auth() -> id();
+        $model -> {$this->deleted_by} = auth() -> id();
         $model -> save();
     }
 }

--- a/src/Listeners/Restoring.php
+++ b/src/Listeners/Restoring.php
@@ -2,20 +2,20 @@
 
 namespace Wildside\Userstamps\Listeners;
 
-class Restoring {
+class Restoring extends Controller {
 
     /**
      * When the model is being restored.
      *
-     * @param Illuminate\Database\Eloquent $model
+     * @param Illuminate\Database\Eloquent\Model|static
      * @return void
      */
     public function handle($model)
     {
-        if (! $model -> isUserstamping()) {
+        if (! $this->prep($model)) {
             return;
         }
 
-        $model -> deleted_by = null;
+        $model -> {$this->deleted_by} = null;
     }
 }

--- a/src/Listeners/Updating.php
+++ b/src/Listeners/Updating.php
@@ -2,20 +2,20 @@
 
 namespace Wildside\Userstamps\Listeners;
 
-class Updating {
+class Updating extends Controller {
 
     /**
      * When the model is being updated.
      *
-     * @param Illuminate\Database\Eloquent $model
+     * @param Illuminate\Database\Eloquent\Model|static
      * @return void
      */
     public function handle($model)
     {
-        if (! $model -> isUserstamping()) {
+        if (! $this->prep($model)) {
             return;
         }
 
-        $model -> updated_by = auth() -> id();
+        $model -> {$this->updated_by} = auth() -> id();
     }
 }


### PR DESCRIPTION
This PR changes the code to allow the use of custom column names.

I have emulated Laravel's timestamp column syntax while still honoring the default names already in use by this trait.

In an effort to remain DRY, I created a controller class to act as an intermediary and handle the column names as well as the `isUserstamping()` check since it was being repeated and made more sense in a single location once that location had been created.

These changes will not alter the way the trait is used or called. It only adds functionality on top.