### PR TITLE
Allow Userstamps to synchronize with Laravel's Timestamps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,17 @@ $model -> editor; // the user who last updated the model
 $model -> destroyer; // the user who deleted the model
 ```
 
-If you want to manually set the `created_by` or `updated_by` properties on your model you can stop Userstamps being automatically maintained using the `stopUserstamping` method.
+You can use the following methods to control Userstamps and Timestamps as needed.
+
+```php
+$model -> stopUserstamping();
+$model -> startUserstamping();
+$model -> stopTimestamping();
+$model -> startTimestamping();
+```
+For example, if you want to manually set the `created_by` or `updated_by` properties on your model you would stop Userstamps being automatically maintained using the `stopUserstamping` method.
+
+Userstamping will stop being automatically maintained by default if you stop the Laravel Timestamping. To override this ability, set `$syncUserWithTime = false;` on your model.
 
 If you want to define the `created_by`, `updated_by`, or `deleted_by` column names, add the following class constants to your model(s).
 ```php

--- a/src/Userstamps.php
+++ b/src/Userstamps.php
@@ -157,6 +157,34 @@ trait Userstamps {
     }
 
     /**
+     * Stop maintaining Timestamps on the model and update Userstamps if we are syncronizing.
+     *
+     * @return void
+     */
+    public function stopTimestamping()
+    {
+        $this -> timestamps = false;
+
+        if ($this -> syncUserWithTime) {
+            $this -> userstamping = false;
+        }
+    }
+
+    /**
+     * Start maintaining Timestamps on the model and update Userstamps if we are syncronizing.
+     *
+     * @return void
+     */
+    public function startTimestamping()
+    {
+        $this -> timestamps = true;
+
+        if ($this -> syncUserWithTime) {
+            $this -> userstamping = true;
+        }
+    }
+
+    /**
      * Get the class being used to provide a User.
      *
      * @return string

--- a/src/Userstamps.php
+++ b/src/Userstamps.php
@@ -12,6 +12,13 @@ trait Userstamps {
     protected $userstamping = true;
 
     /**
+     * Whether we should sync status with timestamps.
+     *
+     * @param bool
+     */
+    protected $syncUserWithTime = true;
+
+    /**
      * Boot the userstamps trait for a model.
      *
      * @return void
@@ -108,33 +115,45 @@ trait Userstamps {
     }
 
     /**
-     * Check if we're maintaing Userstamps on the model.
+     * Check if we're maintaing Userstamps on the model. Use Timestamps value if we are syncronizing and update to reflect
      *
      * @return bool
      */
     public function isUserstamping()
     {
+        if ($this -> syncUserWithTime) {
+            $this -> userstamping = $this -> timestamps;
+        }
+ 
         return $this -> userstamping;
     }
 
     /**
-     * Stop maintaining Userstamps on the model.
+     * Stop maintaining Userstamps on the model and update Timestamps if we are syncronizing.
      *
      * @return void
      */
     public function stopUserstamping()
     {
         $this -> userstamping = false;
+
+        if ($this -> syncUserWithTime) {
+            $this -> timestamps = false;
+        }
     }
 
     /**
-     * Start maintaining Userstamps on the model.
+     * Start maintaining Userstamps on the model and update Timestamps if we are syncronizing.
      *
      * @return void
      */
     public function startUserstamping()
     {
         $this -> userstamping = true;
+
+        if ($this -> syncUserWithTime) {
+            $this -> timestamps = true;
+        }
     }
 
     /**


### PR DESCRIPTION
[Laravel documentation](https://laravel.com/docs/master/eloquent) includes instructions for disabling automatic timestamps on a model.

> If you do not wish to have [timestamps] automatically managed by Eloquent, set the  `$timestamps` property on your model to `false`:

Since Userstamps  work alongside Timestamps, the expected behavior is that the Userstamps would stop automatically maintaining as well. This does not currently happen. The current behavior is not an issue if the Model does not support Stamping of any kind, but it becomes more difficult when adjusting on the fly with, for example, update events. Therefore I offer the following changes:

1. By default, turn off Userstamps if the Timestamps are not being maintained and vice versa.
2. Add semantically similar methods, like those offered for Userstamps, to control Timestamps.
3. If a method is used to start or stop a Stamping event, automatically adjust the sister Stamp.

It would be trivial to stop syncronization if necessary. As the updated README explains, setting the variable `$syncUserWithTime = false;` on a per modal basis would allow the Stamps to act independently. If a developer uses the Laravel documented way of turning off Timestamping, this behavior is accounted for by using `$model->timestamps;` as the default value, allowing for backwards compatibly as well as ease of use in delivering the expected result.