### PR TITLE
Replace hardcoded column names

### DIFF
--- a/src/Userstamps.php
+++ b/src/Userstamps.php
@@ -58,7 +58,7 @@ trait Userstamps {
      */
     public function creator()
     {
-        return $this -> belongsTo($this -> getUserClass(), 'created_by');
+        return $this -> belongsTo($this -> getUserClass(), $this->getCreatedByColumn());
     }
 
     /**
@@ -66,7 +66,7 @@ trait Userstamps {
      */
     public function editor()
     {
-        return $this -> belongsTo($this -> getUserClass(), 'updated_by');
+        return $this -> belongsTo($this -> getUserClass(), $this->getUpdatedByColumn());
     }
 
     /**
@@ -74,7 +74,7 @@ trait Userstamps {
      */
     public function destroyer()
     {
-        return $this -> belongsTo($this -> getUserClass(), 'deleted_by');
+        return $this -> belongsTo($this -> getUserClass(), $this->getDeletedByColumn());
     }
 
     /**

--- a/src/Userstamps.php
+++ b/src/Userstamps.php
@@ -58,7 +58,7 @@ trait Userstamps {
      */
     public function creator()
     {
-        return $this -> belongsTo($this -> getUserClass(), $this->getCreatedByColumn());
+        return $this -> belongsTo($this -> getUserClass(), $this -> getCreatedByColumn());
     }
 
     /**
@@ -66,7 +66,7 @@ trait Userstamps {
      */
     public function editor()
     {
-        return $this -> belongsTo($this -> getUserClass(), $this->getUpdatedByColumn());
+        return $this -> belongsTo($this -> getUserClass(), $this -> getUpdatedByColumn());
     }
 
     /**
@@ -74,7 +74,7 @@ trait Userstamps {
      */
     public function destroyer()
     {
-        return $this -> belongsTo($this -> getUserClass(), $this->getDeletedByColumn());
+        return $this -> belongsTo($this -> getUserClass(), $this -> getDeletedByColumn());
     }
 
     /**


### PR DESCRIPTION
The `creator`, `editor`, `destroyer` had hard coded column names in the `belongsTo` function.

#20 