### PR TITLE
Prevent "update" and "save" events from being fired on deletions

### DIFF
--- a/src/Listeners/Deleting.php
+++ b/src/Listeners/Deleting.php
@@ -20,6 +20,12 @@ class Deleting {
             $model -> {$model -> getDeletedByColumn()} = auth() -> id();
         }
 
+        $dispatcher = $model -> getEventDispatcher();
+
+        $model -> unsetEventDispatcher();
+
         $model -> save();
+
+        $model -> setEventDispatcher($dispatcher);
     }
 }


### PR DESCRIPTION
This fix #23 please check that everything works fine before merge

I'm using Laravel 5.4 btw