### PR TITLE
Allow to configure filling of the `updated_by` column on Model creation

### DIFF
--- a/src/Listeners/Creating.php
+++ b/src/Listeners/Creating.php
@@ -17,8 +17,10 @@ class Creating
             $model->{$model->getCreatedByColumn()} = Userstamps::getUserId();
         }
 
-        if (! is_null($model->getUpdatedByColumn()) && is_null($model->{$model->getUpdatedByColumn()})) {
-            $model->{$model->getUpdatedByColumn()} = Userstamps::getUserId();
+        if ($model->isFillingUpdatedByOnCreate()) {
+            if (! is_null($model->getUpdatedByColumn()) && is_null($model->{$model->getUpdatedByColumn()})) {
+                $model->{$model->getUpdatedByColumn()} = Userstamps::getUserId();
+            }
         }
     }
 }

--- a/src/Traits/Userstamps.php
+++ b/src/Traits/Userstamps.php
@@ -7,6 +7,7 @@ use Mattiverse\Userstamps\UserstampsScope;
 trait Userstamps
 {
     protected bool $userstamping = true;
+    protected bool $fillUpdatedByOnCreate = true;
 
     public static function bootUserstamps(): void
     {
@@ -80,6 +81,21 @@ trait Userstamps
     public function startUserstamping(): void
     {
         $this->userstamping = true;
+    }
+
+    public function isFillingUpdatedByOnCreate(): bool
+    {
+        return $this->fillUpdatedByOnCreate;
+    }
+
+    public function stopFillingUpdatedByOnCreate(): void
+    {
+        $this->fillUpdatedByOnCreate = false;
+    }
+
+    public function startFillingUpdatedByOnCreate(): void
+    {
+        $this->fillUpdatedByOnCreate = true;
     }
 
     protected function getUserClass(): string


### PR DESCRIPTION
Add a property  to enable or disable the filling of the updated_by column on creation, this should retain the current behavior by default.